### PR TITLE
Fix two issues preventing Garmin devices working

### DIFF
--- a/mtp/mtp.go
+++ b/mtp/mtp.go
@@ -210,14 +210,23 @@ func (d *Device) ID() (string, error) {
 		d.devDescr.Manufacturer,
 		d.devDescr.Product,
 		d.devDescr.SerialNumber} {
-		s, err := d.h.GetStringDescriptorASCII(b)
-		if err != nil {
-			if d.USBDebug {
-				log.Printf("USB: GetStringDescriptorASCII, err: %v", err)
+		var descriptor string
+		if b == 0 {
+			// All three of the descriptors are optional.
+			// Index of 0 means the string is not available.
+			descriptor = ""
+		} else {
+			s, err := d.h.GetStringDescriptorASCII(b)
+			if err != nil {
+				if d.USBDebug {
+					log.Printf("USB: GetStringDescriptorASCII, err: %v", err)
+				}
+				return "", err
 			}
-			return "", err
+			descriptor = s
 		}
-		ids = append(ids, s)
+
+		ids = append(ids, descriptor)
 	}
 
 	return strings.Join(ids, " "), nil

--- a/mtp/mtp.go
+++ b/mtp/mtp.go
@@ -304,21 +304,21 @@ func (d *Device) sendReq(req *Container) error {
 
 // Fetches one USB packet. The header is split off, and the remainder is returned.
 // dest should be at least 512bytes.
-func (d *Device) fetchPacket(dest []byte, header *usbBulkHeader) (rest []byte, err error) {
+func (d *Device) fetchPacket(dest []byte, header *usbBulkHeader) (rest []byte, bytesRead int, err error) {
 	n, err := d.h.BulkTransfer(d.fetchEP, dest[:d.fetchMaxPacketSize()], d.Timeout)
 	if n > 0 {
 		d.dataPrint(d.fetchEP, dest[:n])
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, n, err
 	}
 
 	buf := bytes.NewBuffer(dest[:n])
 	if err = binary.Read(buf, binary.LittleEndian, header); err != nil {
-		return nil, err
+		return nil, n, err
 	}
-	return buf.Bytes(), nil
+	return buf.Bytes(), n, nil
 }
 
 func (d *Device) decodeRep(h *usbBulkHeader, rest []byte, rep *Container) error {
@@ -419,7 +419,7 @@ func (d *Device) runTransaction(req *Container, rep *Container,
 	fetchPacketSize := d.fetchMaxPacketSize()
 	data := make([]byte, fetchPacketSize)
 	h := &usbBulkHeader{}
-	rest, err := d.fetchPacket(data[:], h)
+	rest, n, err := d.fetchPacket(data[:], h)
 	if err != nil {
 		return err
 	}
@@ -438,9 +438,10 @@ func (d *Device) runTransaction(req *Container, rep *Container,
 
 		dest.Write(rest)
 
-		if len(rest)+usbHdrLen == fetchPacketSize {
-			// If this was a full packet, read until we
-			// have a short read.
+		if len(rest)+usbHdrLen == fetchPacketSize || uint32(n) < h.Length {
+			// If this was a full packet, or if the packet wasn't full but
+			// the device said it was sending more data than we received,
+			// continue reading until we have a read less than a full packet.
 			_, finalPacket, err = d.bulkRead(dest, progressCb)
 			if err != nil {
 				return err
@@ -456,7 +457,7 @@ func (d *Device) runTransaction(req *Container, rep *Container,
 			finalBuf := bytes.NewBuffer(finalPacket[:len(finalPacket)])
 			err = binary.Read(finalBuf, binary.LittleEndian, h)
 		} else {
-			rest, err = d.fetchPacket(data[:], h)
+			rest, _, err = d.fetchPacket(data[:], h)
 		}
 	}
 


### PR DESCRIPTION
Fixes a couple of implementation issues preventing Garmin devices working correctly with OpenMTP (https://github.com/ganeshrvel/openmtp/issues/153).

First, Garmin devices don't typically populate all three device descriptors - usually only the SerialNumber string is available. Previously, we would fail early if any string was unavailable.

Second, Garmin devices separate the header from payload during the data phase. It _seems_ like we previously assumed that if that were the case then the packet would be full, but that's not necessarily true. I've added a check so if we read less than the size the device has said it's going to send, that will also trigger a bulk read of the payload.

**Note:**
This code was committed on a different computer than was developed, so it probably needs secondary verification. Also, I'm not a Go developer so this may need formatting/rewriting to conform to Go standards.