### PR TITLE
Add fujifilm camera support

### DIFF
--- a/mtp/mtp.go
+++ b/mtp/mtp.go
@@ -170,11 +170,14 @@ func (d *Device) Open() error {
 	d.claim()
 
 	if d.ifaceDescr.InterfaceStringIndex == 0 {
-		// Some of the win8phones have no interface field.
+		// Some devices have no interface field, so we'll hardcode ones
+		// that we know about. If this list gets too unwieldy, we may
+		// need to look into a more generic solution.
 		info := DeviceInfo{}
 		d.GetDeviceInfo(&info)
 
-		if !strings.Contains(info.MTPExtension, "microsoft/WindowsPhone") {
+		if !strings.Contains(info.MTPExtension, "microsoft/WindowsPhone") &&
+			!strings.Contains(info.MTPExtension, "fujifilm.co.jp") {
 			d.Close()
 			return fmt.Errorf("mtp: no MTP extensions in %s", info.MTPExtension)
 		}


### PR DESCRIPTION
Fujifilm cameras, like Windows Phone 8 devices, don't send an InterfaceStringIndex.
This patch adds a similar exception to Open() to handle those cameras.

In the future, we want to make this more generic, depending on the number of devices this applies to.

Should help https://github.com/ganeshrvel/openmtp/issues/259

Edit: removed the fixed keyword so that issue doesn’t get auto-closed