### PR TITLE
Fix failing to send data to Garmin devices

### DIFF
--- a/mtp/mtp.go
+++ b/mtp/mtp.go
@@ -450,8 +450,10 @@ func (d *Device) runTransaction(req *Container, rep *Container,
 			// data packet AND it's 12 bytes, set SeparateHeader to TRUE so we
 			// correctly send data back to the receiver.
 			if n == usbHdrLen && len(rest) == 0 && uint32(n) < h.Length {
-				log.Printf("Device appears to have split header/data. Switch to separate header mode.")
 				d.SeparateHeader = true
+				if d.MTPDebug {
+					log.Printf("Device appears to have split header/data. Switched to separate header mode.")
+				}
 			}
 
 			// If this was a full packet, or if the packet wasn't full but


### PR DESCRIPTION
The fix made in PR #1 wasn't the complete fix for devices that support split header/payload functionality, like Garmin devices. It turns out that once either side has switched to that "separate" mode, _both sides_ need to communicate in that format:

![image](https://user-images.githubusercontent.com/484512/199878119-a4027202-f474-4c46-8b5e-0c7851a5b872.png)

To that end, this patch turns on `d.SeparateHeader` mode (which apparently is already implemented but was unused?) if we think that the device might be in that mode.

In theory https://github.com/ganeshrvel/openmtp/issues/153 should be fixed but despite being able to get go-mtpfs working:
<img width="682" alt="Screen Shot 2022-11-03 at 10 16 31 PM" src="https://user-images.githubusercontent.com/484512/199878658-59e261ae-999b-4683-89a2-148bf6335fb5.png">

And go-mtpx unit tests _mostly_ passing (the watch seems to get into a bad state at one point near the end of the tests and doesn't reconnect):
<img width="250" alt="Screen Shot 2022-11-03 at 10 24 42 PM" src="https://user-images.githubusercontent.com/484512/199878720-342ab098-2106-4002-bdee-1869e94295c1.png">

I haven't been able to get OpenMTP to list files out yet. 😞 